### PR TITLE
feat: WebSocket のサイレント接続死を検出して自動再接続する機能を追加

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -577,7 +577,9 @@ class WatchVRChatUser {
 
     console.log('[MAIN] Polling users status...')
 
-    if (!this.vrchat) {
+    // VRChat クライアントのスナップショット（ループ中に null になることを防ぐ）
+    const vrchat = this.vrchat
+    if (!vrchat) {
       console.warn(
         '[MAIN] VRChat client is not initialized, skipping API polling'
       )
@@ -588,7 +590,7 @@ class WatchVRChatUser {
     for (const userId of this.config.targetUserIds) {
       try {
         // API からユーザー状態を取得
-        const userInfo = await getUser(this.vrchat, userId)
+        const userInfo = await getUser(vrchat, userId)
 
         if (!userInfo) {
           console.warn(`[MAIN] Failed to fetch user info for ${userId}`)

--- a/src/vrchat-client.ts
+++ b/src/vrchat-client.ts
@@ -217,6 +217,14 @@ export async function getUser(
   const result = await vrchat.getUser({ path: { userId } })
 
   if (result.error) {
+    // 429 エラー（レート制限）の場合は例外を投げる
+    if (
+      result.error.message.includes('429') ||
+      result.error.message.toLowerCase().includes('rate limit')
+    ) {
+      throw new Error(`Rate limit error (429): ${result.error.message}`)
+    }
+
     console.error(
       `[VRCHAT] Failed to get user ${userId}: ${result.error.message}`
     )

--- a/src/websocket-monitor.ts
+++ b/src/websocket-monitor.ts
@@ -161,7 +161,17 @@ export class WebSocketMonitor {
 
     // WebSocket を閉じて handleDisconnect() をトリガー
     if (this.vrchat) {
-      this.vrchat.pipeline.close()
+      try {
+        this.vrchat.pipeline.close()
+      } catch (error) {
+        console.error(
+          '[MONITOR] Failed to close WebSocket pipeline for forced reconnect:',
+          error
+        )
+
+        // フォールバック: 直接 handleDisconnect() を呼び出す
+        this.handleDisconnect()
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

WebSocket 接続がサイレントに死んでいる（connected 状態を維持しているが、実際にはイベントを受信していない）状態を検出し、自動的に再接続する機能を追加しました。

## 主な機能・変更点

### WebSocketMonitor (`src/websocket-monitor.ts`)

- **`requestReconnect(reason: string)` メソッドを追加**
  - 強制的に再接続を要求するメソッド
  - 既存の単一フライト制御・バックオフに合流
  - `stopped` 状態や `isReconnecting` の場合はスキップ

- **`EVENT_TIMEOUT_WARNING` を 24 時間から 6 時間に変更**
  - イベント未受信の警告閾値を短縮
  - より迅速なサイレント接続死の検出が可能に

### Main (`src/main.ts`)

- **API ポーリングロジックの追加**
  - 1 時間ごとに VRChat API (`vrchat.users.getUser(userId)`) を呼び出してユーザーの状態を取得
  - 各ユーザーに対して逐次実行（バースト防止）
  - `pollUsersStatus()` メソッド: API ポーリングを実行
  - `checkSilentDeath()` メソッド: サイレント接続死の判定を実行

- **乖離検出と自動再接続**
  - API で取得した Location と LocationStore に保存された Location を比較
  - 以下の条件をすべて満たす場合のみ再接続:
    1. WebSocket が接続状態（`monitor.getState() === 'connected'`）
    2. 最後のイベント受信時刻が 6 時間以上古い
    3. API で取得した Location が LocationStore と異なる

- **API エラーハンドリング**
  - 429 エラー（レート制限）時の 30 分間クールダウン機能を実装
  - レート制限を適切に回避し、API の安定性を確保

- **シャットダウン時の処理**
  - API ポーリングタイマーのクリア処理を追加

## テスト結果

- `pnpm fix`: ✅ Lint / Format エラーなし
- `pnpm test`: ✅ すべてのテストがパス

## 設計方針

### 検出方法
- 定期的な API ポーリング（1 時間ごと）と WebSocket イベントを併用
- 単純な時間ベースの判定（48 時間経過）ではなく、API との乖離を検出することで誤検知を防止

### 再接続条件
- WebSocket が接続状態かつ 6 時間以上イベント未受信かつ Location が異なる場合
- 3 つの条件をすべて満たす場合のみ再接続し、誤検知を最小限に抑える

### エラーハンドリング
- API エラー（401/429/ネットワーク）は適切にハンドリング
- 429 エラー時は 30 分間クールダウンし、レート制限を回避
- その他のエラーはログ出力のみで再接続しない

### パフォーマンス
- API ポーリングは 1 時間ごと（1 日 24 リクエスト）で、VRChat API の推奨レート（1 分あたり 1 リクエスト）と比較して非常に低頻度
- 複数ユーザーの場合でも逐次実行でバーストを防止

## Discord 通知
- 強制再接続時は Discord に通知しない（ログのみ）

## コードレビュー対応

コードレビューで発見された以下の問題を修正しました（コミット: 8c48ff8）:

### 修正内容

1. **429 エラーハンドリングの改善** (スコア: 60)
   - 単純なフラグから 30 分間のクールダウンに変更
   - `apiPollCooldownUntil` タイムスタンプで管理
   - レート制限を適切に回避

2. **SIX_HOURS 定数の重複解消** (スコア: 75)
   - クラスの定数として定義し、重複を解消
   - WebSocketMonitor の `EVENT_TIMEOUT_WARNING` との関連をコメントで明示

3. **EVENT_TIMEOUT_WARNING 変更の明確化** (スコア: 80)
   - コメントを追加し、動作変更を明示
   - `performHealthCheck()` と `checkSilentDeath()` での使用を文書化

4. **タイマー重複防止の追加** (スコア: 65)
   - `startApiPoller()` に既存タイマーのチェックを追加
   - 重複起動を防止

5. **requestReconnect() の JSDoc 改善** (スコア: 50)
   - 実装詳細（`pipeline.close()` → `handleDisconnect()`）を JSDoc に追加
   - より明確な説明に変更

## 判断記録

### エージェント相談結果

#### Codex CLI からの指摘
- **LocationStore の使い方**: ポーリング結果で LocationStore を更新しないことで、差分通知が潰れるのを防ぐ（採用）
- **既存の再接続ロジックとの競合**: `WebSocketMonitor` に `requestReconnect()` メソッドを追加し、単一フライト制御に合流（採用）
- **パフォーマンスとレート制限**: 逐次実行と 429 エラー時のクールダウンを実装（採用）
- **誤検知を減らす条件**: 3 つの条件をすべて満たす場合のみ再接続（採用）

#### Gemini CLI からの指摘
- **VRChat API のレート制限**: 1 時間ごとのポーリングは推奨レートと比較して非常に低頻度。429 エラー時のクールダウンを実装（採用）
- **既存のイベント監視との重複**: ポーリングは乖離検出のみに使用し、LocationStore は更新しない（部分採用）

## 関連 Issue

- Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)