### PR TITLE
feat(discord): embed のタイトルにユーザー名を表示する

### DIFF
--- a/src/discord-notifier.ts
+++ b/src/discord-notifier.ts
@@ -70,7 +70,7 @@ export class DiscordNotifier {
    */
   async notifyLocationChange(params: LocationChangeParams): Promise<void> {
     const embed: DiscordEmbed = {
-      title: '\u{1F4CD} ロケーション変更',
+      title: `\u{1F4CD} ${params.displayName} ロケーション変更`,
       color: COLORS.locationChange,
       fields: [
         {
@@ -118,7 +118,7 @@ export class DiscordNotifier {
    */
   async notifyOnline(params: OnlineParams): Promise<void> {
     const embed: DiscordEmbed = {
-      title: '\u{1F7E2} オンライン',
+      title: `\u{1F7E2} ${params.displayName} オンライン`,
       color: COLORS.online,
       fields: [
         {
@@ -140,7 +140,7 @@ export class DiscordNotifier {
    */
   async notifyOffline(params: OfflineParams): Promise<void> {
     const embed: DiscordEmbed = {
-      title: '\u{26AB} オフライン',
+      title: `\u{26AB} ${params.displayName} オフライン`,
       color: COLORS.offline,
       fields: [
         {


### PR DESCRIPTION
## 変更内容

Discord 通知 embed のタイトルに対象ユーザーの表示名を追加しました。

### 変更前後

| 通知種別 | 変更前 | 変更後 |
|---|---|---|
| ロケーション変更 | 📍 ロケーション変更 | 📍 UserName ロケーション変更 |
| オンライン | 🟢 オンライン | 🟢 UserName オンライン |
| オフライン | ⚫ オフライン | ⚫ UserName オフライン |

## 変更ファイル

- `src/discord-notifier.ts`: 各通知メソッドの embed タイトルに `displayName` を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)