### PR TITLE
fix(websocket-monitor): 再接続後にイベントが来ない場合もバックアップ再接続が発火するよう修正

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -688,15 +688,18 @@ class WatchVRChatUser {
       return
     }
 
-    // 条件 2: 最後のイベント受信時刻が 6 時間以上古いこと
-    const lastEventTime = this.monitor.getLastEventTime()
-    if (!lastEventTime) {
-      // まだイベントを受信していない場合はスキップ
+    // 条件 2: 最後のイベント受信時刻（またはフォールバックとして接続確立時刻）が 6 時間以上古いこと
+    // lastEventTime が null の場合は connectedAt を基準とする。
+    // これにより、再接続後にイベントが一切来ない（サーバー側ゾンビ状態）でも
+    // サイレントデス判定が正しく機能する。
+    const referenceTime =
+      this.monitor.getLastEventTime() ?? this.monitor.getConnectedAt()
+    if (!referenceTime) {
       return
     }
 
     const now = new Date()
-    const timeSinceLastEvent = now.getTime() - lastEventTime.getTime()
+    const timeSinceLastEvent = now.getTime() - referenceTime.getTime()
 
     if (timeSinceLastEvent < this.SIX_HOURS) {
       return

--- a/src/main.ts
+++ b/src/main.ts
@@ -699,9 +699,9 @@ class WatchVRChatUser {
     }
 
     const now = new Date()
-    const timeSinceLastEvent = now.getTime() - referenceTime.getTime()
+    const timeSinceReference = now.getTime() - referenceTime.getTime()
 
-    if (timeSinceLastEvent < this.SIX_HOURS) {
+    if (timeSinceReference < this.SIX_HOURS) {
       return
     }
 
@@ -709,7 +709,7 @@ class WatchVRChatUser {
 
     // すべての条件を満たす場合、強制再接続
     console.warn(
-      `[MAIN] Silent death detected for user ${userId}: API=${apiLocation ?? 'offline'}, Store=${storeLocation ?? 'offline'}, Time since last event=${timeSinceLastEvent / 1000 / 60 / 60} hours`
+      `[MAIN] Silent death detected for user ${userId}: API=${apiLocation ?? 'offline'}, Store=${storeLocation ?? 'offline'}, Time since reference=${timeSinceReference / 1000 / 60 / 60} hours`
     )
 
     this.monitor.requestReconnect('Silent death detected')

--- a/src/websocket-monitor.ts
+++ b/src/websocket-monitor.ts
@@ -39,6 +39,8 @@ export class WebSocketMonitor {
   private state: ConnectionState = 'connecting'
   private vrchat: VRChat | null = null
   private lastEventTime: Date | null = null
+  /** 現在の接続が確立された時刻 */
+  private connectedAt: Date | null = null
   private reconnectAttempts = 0
   private reconnectTimer: NodeJS.Timeout | null = null
   private healthCheckTimer: NodeJS.Timeout | null = null
@@ -214,6 +216,15 @@ export class WebSocketMonitor {
   }
 
   /**
+   * 現在の接続が確立された時刻を取得する
+   *
+   * @returns 接続確立時刻（未接続の場合は null）
+   */
+  getConnectedAt(): Date | null {
+    return this.connectedAt
+  }
+
+  /**
    * VRChat クライアントを取得する
    *
    * @returns VRChat クライアント（未接続の場合は null）
@@ -377,6 +388,8 @@ export class WebSocketMonitor {
 
       // 再接続後に lastEventTime をリセットして新しい接続に新鮮な計測ウィンドウを与える
       this.lastEventTime = null
+      // 接続確立時刻を記録（lastEventTime が null の間のバックアップ基準時刻として使用）
+      this.connectedAt = new Date()
 
       console.log('[MONITOR] Connected to VRChat WebSocket')
 
@@ -559,20 +572,23 @@ export class WebSocketMonitor {
       return
     }
 
-    if (!this.lastEventTime) {
-      // まだイベントを受信していない場合はスキップ
+    // lastEventTime が null の場合は connectedAt を基準とする。
+    // これにより、再接続後にイベントが一切来ない（サーバー側ゾンビ状態）でも
+    // バックアップ再接続が正しく発火する。
+    const referenceTime = this.lastEventTime ?? this.connectedAt
+    if (!referenceTime) {
       return
     }
 
     const now = new Date()
-    const timeSinceLastEvent = now.getTime() - this.lastEventTime.getTime()
+    const timeSinceReference = now.getTime() - referenceTime.getTime()
 
-    if (timeSinceLastEvent > this.EVENT_TIMEOUT_RECONNECT) {
+    if (timeSinceReference > this.EVENT_TIMEOUT_RECONNECT) {
       // 全フレンドのイベントが 10 分以上来ない = WebSocket が実質的に死んでいる可能性が高い
       // ping/pong のバックアップとして強制再接続する
-      const minutes = Math.floor(timeSinceLastEvent / 1000 / 60)
+      const minutes = Math.floor(timeSinceReference / 1000 / 60)
       console.warn(
-        `[MONITOR] No events received for ${minutes} minutes (last: ${this.lastEventTime.toISOString()}). Triggering backup reconnect.`
+        `[MONITOR] No events received for ${minutes} minutes (reference: ${referenceTime.toISOString()}). Triggering backup reconnect.`
       )
       this.requestReconnect(`No events received for ${minutes} minutes`)
     }

--- a/src/websocket-monitor.ts
+++ b/src/websocket-monitor.ts
@@ -216,9 +216,12 @@ export class WebSocketMonitor {
   }
 
   /**
-   * 現在の接続が確立された時刻を取得する
+   * 直近の接続が確立された時刻を取得する
    *
-   * @returns 接続確立時刻（未接続の場合は null）
+   * 切断後・再接続待機中も前回の接続確立時刻を保持するため、
+   * `null` を返すのは初回接続前（アプリ起動直後）のみ。
+   *
+   * @returns 直近の接続確立時刻（初回接続前は null）
    */
   getConnectedAt(): Date | null {
     return this.connectedAt
@@ -562,6 +565,8 @@ export class WebSocketMonitor {
    * 1. pipeline.connected が false → 即座に再接続（既存の切断検出）
    * 2. アプリケーションレベルのイベントが 10 分以上来ない → バックアップ再接続
    *    （ping/pong が機能しない環境への安全網）
+   *    基準時刻は lastEventTime、未受信時は connectedAt をフォールバックとして使用する。
+   *    これにより再接続後にサーバーがイベントを送信しないゾンビ状態でも検知できる。
    */
   private performHealthCheck(): void {
     // VRChat SDK は WebSocket の close/error イベントを EventEmitter に転送しないため、
@@ -569,6 +574,11 @@ export class WebSocketMonitor {
     if (this.vrchat && !this.vrchat.pipeline.connected) {
       console.warn('[MONITOR] WebSocket is not connected, triggering reconnect')
       this.handleDisconnect()
+      return
+    }
+
+    // 接続状態でない場合（再接続中など）はイベントタイムアウトチェックをスキップする
+    if (this.state !== 'connected') {
       return
     }
 


### PR DESCRIPTION
## Summary

- `WebSocketMonitor` に `connectedAt` フィールドを追加し、接続確立時刻を記録する
- `lastEventTime` が `null`（再接続直後でイベント未受信）の場合、`connectedAt` をフォールバック基準時刻として使用する
- `performHealthCheck()` および `checkSilentDeath()` の両方でこの基準時刻を使用するよう修正

## 背景・問題

WebSocket 再接続成功時に `lastEventTime` を `null` にリセットしているが、`performHealthCheck` と `checkSilentDeath` の両方が `lastEventTime == null` を「未受信としてスキップ」していた。このため、再接続後にサーバー側がゾンビ状態（ping/pong は正常だがアプリイベントを送信しない）になると、バックアップ再接続が永遠に発火せず、最長で次の ping タイムアウト（数時間）まで復旧できなかった。

## 修正内容

### `src/websocket-monitor.ts`

- `private connectedAt: Date | null = null` を追加
- `connect()` の接続確立直後に `this.connectedAt = new Date()` を設定
- `getConnectedAt(): Date | null` を公開メソッドとして追加（切断後も前回値を保持）
- `performHealthCheck()` 内で `const referenceTime = this.lastEventTime ?? this.connectedAt` を使用
- `performHealthCheck()` に `state !== 'connected'` の明示的チェックを追加し、再接続中はイベントタイムアウトチェックをスキップ

### `src/main.ts`

- `checkSilentDeath()` 内で `this.monitor.getLastEventTime() ?? this.monitor.getConnectedAt()` を基準時刻として使用
- 変数名を `timeSinceLastEvent` → `timeSinceReference` に統一、ログメッセージも同様に修正

## 効果

再接続後にイベントが一件も来ない場合でも、接続確立から 10 分（`EVENT_TIMEOUT_RECONNECT`）経過でバックアップ再接続が発火する。

- Closes #177