### PR TITLE
fix: traveling 中の通知スキップ・再接続後イベントなし時のバックアップ再接続対応

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -129,6 +129,9 @@ function isFriendOfflineEvent(data: unknown): data is FriendOfflineEvent {
   return typeof obj.userId === 'string'
 }
 
+/** ワールド間移動中の Location 値 */
+const TRAVELING_LOCATION = 'traveling'
+
 /**
  * メインアプリケーションクラス
  */
@@ -303,6 +306,14 @@ class WatchVRChatUser {
         this.locationStore.getLocation(userId)?.location ?? null
       const currentLocation = userInfo.location
 
+      // traveling 中は通知を送らず、ストアも更新しない（前回の location を維持）
+      if (currentLocation === TRAVELING_LOCATION) {
+        console.log(
+          `[MAIN] Initial status: ${userInfo.displayName} (${userId}) - traveling (skipped)`
+        )
+        continue
+      }
+
       // 初期状態を保存
       this.locationStore.setInitialLocation(
         userId,
@@ -470,6 +481,14 @@ class WatchVRChatUser {
     console.log(
       `[MAIN] Friend location event: ${displayName} (${userId}) -> ${location}`
     )
+
+    // traveling 中はストアの更新・通知ともにスキップ
+    if (location === TRAVELING_LOCATION) {
+      console.log(
+        `[MAIN] User ${displayName} (${userId}) is traveling, skipping notification`
+      )
+      return
+    }
 
     // Location を更新
     const result = this.locationStore.updateLocation(
@@ -641,6 +660,14 @@ class WatchVRChatUser {
         const storeLocation =
           this.locationStore.getLocation(userId)?.location ?? null
         const apiLocation = userInfo.location
+
+        // traveling 中は乖離チェックをスキップ
+        if (apiLocation === TRAVELING_LOCATION) {
+          console.log(
+            `[MAIN] User ${userInfo.displayName} (${userId}) is traveling, skipping mismatch check`
+          )
+          continue
+        }
 
         // Location の乖離を検出
         if (apiLocation !== storeLocation) {


### PR DESCRIPTION
## 概要

VRChat でのワールド間移動中（location が `"traveling"`）の Discord 通知をスキップします。

## 背景

VRChat ではユーザーがワールドを移動する際、location が一時的に `"traveling"` になります。この状態は移動中の過渡状態であり、移動先のワールドに到達した時点で実際のワールド ID に更新されます。`"traveling"` 状態での通知は意味がないため、すべての通知対象箇所でスキップ処理を追加しました。

## 変更内容

### `src/main.ts`

- **`handleFriendLocation`**: `location === 'traveling'` の場合、LocationStore の更新・Discord 通知ともにスキップ。ストアを更新しないことで、次のワールド到着時に「WorldA → WorldB」という正確な遷移通知が送られます
- **`fetchInitialUserStatuses`** (起動時): 起動時にユーザーが traveling 中の場合、通知とストア更新をスキップし、前回保存された location を維持します
- **`pollUsersStatus`** (API ポーリング): API が `"traveling"` を返した場合、乖離チェックをスキップして誤った強制再接続を防ぎます

### 設計上のポイント

traveling 時にストアを更新しない理由：
- ストアを `"traveling"` に更新すると、ワールド到着時に「traveling → WorldB」という通知になる（不自然）
- ストアを更新しないことで、「WorldA → WorldB」という自然な通知になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)