### PR TITLE
fix(tsconfig): TypeScript v6.0 の非推奨設定を根本修正する

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,10 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": ["ESNext", "esnext.AsyncIterable"],
     "outDir": "./dist",
     "rootDir": "./src",
-    "ignoreDeprecations": "6.0",
     "types": ["node", "jest"],
     "removeComments": true,
     "esModuleInterop": true,
@@ -25,10 +24,9 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
     "newLine": "LF",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## 概要

TypeScript v6.0 アップグレード時の暫定対応として追加していた `ignoreDeprecations: "6.0"` を削除し、非推奨設定を根本的に修正します。

## 変更内容

### `tsconfig.json`

| 変更項目 | 変更前 | 変更後 |
|---------|--------|--------|
| `moduleResolution` | `"Node"` | `"bundler"` |
| `ignoreDeprecations` | `"6.0"` | 削除 |
| `baseUrl` | `"."` | 削除 |
| `paths["@/*"]` | `["src/*"]` | `["./src/*"]` |

### 変更の理由

1. **`moduleResolution: "bundler"`** — TypeScript 6.0 で非推奨となった `"Node"` の代替として推奨される設定。CJS と組み合わせ可能
2. **`ignoreDeprecations: "6.0"` 削除** — TypeScript 7.0 では機能しなくなるため、根本対応に切り替え
3. **`baseUrl: "."` 削除 + `paths` を相対パスに更新** — `baseUrl` 削除に伴い、`paths` のエントリを tsconfig.json 起点の相対パス `"./src/*"` に変更

## 確認事項

- [x] `tsc --noEmit` でビルドエラーなし
- [x] `pnpm lint` (TypeScript / ESLint / Prettier) がすべてパス

## 関連 Issue

- Fixes #250