### PR TITLE
fix(pnpm): pnpm v11 の設定移行漏れを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk update && \
 
 WORKDIR /app
 
-COPY pnpm-lock.yaml package.json ./
+COPY pnpm-lock.yaml package.json pnpm-workspace.yaml ./
 COPY patches patches
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch

--- a/package.json
+++ b/package.json
@@ -72,10 +72,5 @@
       ]
     }
   },
-  "packageManager": "pnpm@10.34.4",
-  "pnpm": {
-    "patchedDependencies": {
-      "vrchat@2.20.7": "patches/vrchat@2.20.7.patch"
-    }
-  }
+  "packageManager": "pnpm@10.34.4"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,5 @@ allowBuilds:
   unrs-resolver: true
 minimumReleaseAgeExclude:
   - '@book000/*'
+patchedDependencies:
+  vrchat@2.20.7: patches/vrchat@2.20.7.patch


### PR DESCRIPTION
## 概要

Renovate PR #139 (`packageManager` pnpm 10.34.4 -> 11.10.0) の CI が失敗していた原因を調査し、pnpm v11 移行に伴う設定漏れを修正する。

## 原因

pnpm v11 で `package.json` の `pnpm` フィールドが読まれなくなり、設定は `pnpm-workspace.yaml` に移設された(本リポジトリでは `allowBuilds` は #165 で既に移設済みだったが、`patchedDependencies` が未移設だった)。

1. **Node CI**: `patchedDependencies` が読まれなくなった結果、`vrchat` パッケージの `dist/index.d.ts`(`var version = ...` を `declare const version = ...` に修正するパッチ)が適用されなくなり、`tsc` が TS1046/TS1039 エラーで失敗する。
2. **Docker CI**: `Dockerfile` の builder stage が `pnpm-workspace.yaml` をビルドコンテキストにコピーしていなかったため、`minimumReleaseAgeExclude`(#191、`@book000/*` を除外)が `pnpm fetch` に反映されず、直近リリースされた `@book000/node-utils` パッケージで `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` が発生する。

## 対応

- `patchedDependencies` を `package.json` から `pnpm-workspace.yaml` に移設
- `Dockerfile` の `COPY` に `pnpm-workspace.yaml` を追加

## 確認

- pnpm v10.34.4(現行 `packageManager`)で `pnpm install` / `pnpm run lint` / `pnpm test` が問題なく通ることを確認(後方互換)
- `packageManager` を一時的に `pnpm@11.10.0` に変更してローカル検証し、パッチが正しく適用され `pnpm run lint` が通ることを確認
- `docker build --target builder` を `pnpm@11.10.0` で実行し、`pnpm fetch` が成功することを確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)