### PR TITLE
fix(deps): update dependency vrchat to v2.22.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@book000/node-utils": "1.24.274",
     "keyv": "5.6.0",
     "keyv-file": "5.3.5",
-    "vrchat": "2.20.7"
+    "vrchat": "2.22.7"
   },
   "devDependencies": {
     "@book000/eslint-config": "1.15.4",
@@ -75,7 +75,7 @@
   "packageManager": "pnpm@10.34.4",
   "pnpm": {
     "patchedDependencies": {
-      "vrchat@2.20.7": "patches/vrchat@2.20.7.patch"
+      "vrchat@2.22.7": "patches/vrchat@2.22.7.patch"
     }
   }
 }

--- a/patches/vrchat@2.22.7.patch
+++ b/patches/vrchat@2.22.7.patch
@@ -6,7 +6,7 @@ index b2cf019580659dc2431d9250eb09f196f73c474c..03de2ab587296514e6dccb52f16a7399
  import 'keyv';
  import 'typed-emitter';
  
--var version = "2.20.7";
-+declare const version = "2.20.7";
+-var version = "2.22.7";
++declare const version = "2.22.7";
  
  export { version };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  vrchat@2.20.7:
-    hash: 8c6c403319e9143d54e9e1a6d3082688327e7f07760e905843b11ae7c7d0c933
-    path: patches/vrchat@2.20.7.patch
+  vrchat@2.22.7:
+    hash: a452b18fc8779b4bad5d36c15e559e9ddf4725295dd7638a9085c2bc7e529856
+    path: patches/vrchat@2.22.7.patch
 
 importers:
 
@@ -23,8 +23,8 @@ importers:
         specifier: 5.3.5
         version: 5.3.5
       vrchat:
-        specifier: 2.20.7
-        version: 2.20.7(patch_hash=8c6c403319e9143d54e9e1a6d3082688327e7f07760e905843b11ae7c7d0c933)
+        specifier: 2.22.7
+        version: 2.22.7(patch_hash=a452b18fc8779b4bad5d36c15e559e9ddf4725295dd7638a9085c2bc7e529856)
     devDependencies:
       '@book000/eslint-config':
         specifier: 1.15.4
@@ -2812,8 +2812,8 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
-  vrchat@2.20.7:
-    resolution: {integrity: sha512-Ny0PTvHKC/daqfZYUMDJcgeyYmTdl1TYKfkD1mE2yPd22ZGgBu5CUftyFz0EmMc0Z4K9VjBQ+EN67b14hEkF3A==}
+  vrchat@2.22.7:
+    resolution: {integrity: sha512-VBX4j9VLsGUaE0Ydy71rkQLDvvy4yZwiocjWnfIml6Arf88WQ/9BTDsg3abE2XrbGcwqSX88U40Emay6DIo+lQ==}
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
@@ -6170,7 +6170,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  vrchat@2.20.7(patch_hash=8c6c403319e9143d54e9e1a6d3082688327e7f07760e905843b11ae7c7d0c933):
+  vrchat@2.22.7(patch_hash=a452b18fc8779b4bad5d36c15e559e9ddf4725295dd7638a9085c2bc7e529856):
     dependencies:
       cacheable: 1.10.4
       debug: 4.4.3


### PR DESCRIPTION
Renovate PR #21 bumped `vrchat` in `package.json` (2.20.7 -> 2.22.7), but `renovate/artifacts` itself failed ("Artifact file update failure"), leaving `pnpm-lock.yaml` pinned to `vrchat: 2.20.7`. This caused `ERR_PNPM_OUTDATED_LOCKFILE` in both Node CI (`pnpm install --frozen-lockfile`) and Docker CI (`pnpm install --frozen-lockfile --offline`).

This PR regenerates `pnpm-lock.yaml` and renames the version-pinned patch key/file (`patches/vrchat@2.20.7.patch` -> `patches/vrchat@2.22.7.patch`) to match. Confirmed `dist/index.d.ts` in 2.22.7 still has the same `var version = ...` issue the patch fixes (only the version string differs), so the patch content itself is unchanged aside from that string.

Verified locally:
- `pnpm install --frozen-lockfile` succeeds
- `pnpm run lint` (prettier + eslint + tsc) passes clean
- `pnpm test` passes (no tests in repo, exits 0)

Related to #21 (does not close it — Renovate PR is left untouched per policy).